### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,10 +12,10 @@ on:
 jobs:
   eslint:
     name: Code Quality Check
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout code

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   eslint:
     name: Code Quality Check
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v2.1.0/security/code-scanning/1](https://github.com/Org-EthereaLogic/DocDevAI-v2.1.0/security/code-scanning/1)

To fix this problem, explicitly declare the required `permissions` for the job at `.github/workflows/eslint.yml` in the `eslint` job, right beneath its name. The minimal set required for this job is:

- `contents: read` — required to checkout code.
- `pull-requests: write` — required to add or update comments on pull requests via `actions/github-script` (and may be required by annotation actions that create PR comments).

Therefore, add:
```yaml
permissions:
  contents: read
  pull-requests: write
```
Add this as the second line under the `eslint:` job definition (after `name:`).

No changes to functionality are needed; this just restricts the GITHUB_TOKEN as per the job's needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
