### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,4 +1,6 @@
 name: Node.js CI/CD
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DocDevAI-v2.1.0/security/code-scanning/2](https://github.com/Org-EthereaLogic/DocDevAI-v2.1.0/security/code-scanning/2)

To fix the problem, add an explicit top-level `permissions` block to the workflow YAML. This will apply least-privilege permissions to all jobs unless overridden individually. The best practice is to start with `contents: read` at the workflow root, since most jobs only need to read repository contents. If individual jobs require more (e.g., to upload coverage reports, or perform dry-run releases), you can override the permissions at the job level as needed.

This change is implemented by inserting the following block after the `name:` line and before the `on:` line:

```yaml
permissions:
  contents: read
```

In the future, you may customize permissions for jobs like `release-dry-run` (e.g. `contents: write` if doing real releases), but for the current code the minimal fix is to set workflow-wide read-only permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
